### PR TITLE
Add leading zeros to screenshot counter

### DIFF
--- a/extentreports-cucumber7-adapter/src/main/java/com/aventstack/extentreports/cucumber/adapter/ExtentCucumberAdapter.java
+++ b/extentreports-cucumber7-adapter/src/main/java/com/aventstack/extentreports/cucumber/adapter/ExtentCucumberAdapter.java
@@ -87,6 +87,7 @@ public class ExtentCucumberAdapter implements ConcurrentEventListener {
 		}
 	};
 
+	private static final String EMBEDDED_PREFIX = "embedded";
 	private static final AtomicInteger EMBEDDED_INT = new AtomicInteger(0);
 
 	private final TestSourcesModel testSources = new TestSourcesModel();
@@ -242,10 +243,8 @@ public class ExtentCucumberAdapter implements ConcurrentEventListener {
 						.createScreenCaptureFromBase64String(Base64.getEncoder().encodeToString(event.getData()))
 						.build());
 			} else {
-				StringBuilder fileName = new StringBuilder("embedded").append(EMBEDDED_INT.incrementAndGet())
-						.append(".").append(extension);
 				try {
-					URL url = toUrl(fileName.toString());
+					URL url = toUrl(String.format("%s%04d.%s", EMBEDDED_PREFIX, EMBEDDED_INT.incrementAndGet(), extension));
 					writeBytesToURL(event.getData(), url);
 					try {
 						File file = new File(url.toURI());


### PR DESCRIPTION
In some use cases the screenshots are browsed directly using image viewers without using the generated report file.

Some operating systems (e.g. Microsoft Windows) order files by lexicographical order causing the screenshots to be displayed in the incorrect order.

Adding leading zeros to the screenshot counter causes the screenshots to be ordered correctly. Using 4 leading zeros as padding ensures that the screenshots are ordered correctly for at least the first 9999 screenshots.

Closes: #28